### PR TITLE
 added repaired prop to num status

### DIFF
--- a/.NET/Classes/UpdateValidProperties.cs
+++ b/.NET/Classes/UpdateValidProperties.cs
@@ -26,7 +26,7 @@ public static class UpdateHelper
             else if (prop.PropertyType == typeof(int))
             {
                 var num = (int)value;
-                if (num > 0)
+                if (num >= 0)
                 {
                     var targetProp = typeof(TTarget).GetProperty(prop.Name);
                     targetProp?.SetValue(target, num);

--- a/.NET/Services/itemTaskService.cs
+++ b/.NET/Services/itemTaskService.cs
@@ -195,9 +195,6 @@ public class ItemTaskService : ITaskItem
 
 
         */
-
-
-        
         
 
         var response = await _supabaseClient


### PR DESCRIPTION
adicionado um sinal de '=' no  validador de propriedades do backend, ele tava apenas com > ou seja, CASO OS NUMEROS FOSSEM MAIOR QUE ZERO, ele conseguia fazer o patch, se nao, ele dava erro desconhecido, estranho demais.

massss, agora ja ta tudo ok, fiz um teste apenas via api
